### PR TITLE
Move cache directory to be a variable and increase the default backup retention period

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -3,15 +3,28 @@
 #
 define duplicity::backup(
   $destination,
-  $ensure         = present,
-  $source         = '/',
-  $rules          = [],
-  $retention      = '90D',
-  $full           = '15D',
-  $env_var        = [],
-  $volsize        = '200',
-  $args           = '',
-  $encryption_key = '') {
+  $ensure              = present,
+  $source              = '/',
+  $cache_storage_path  = '/opt/duplicity/cache',
+  $rules               = [],
+  $retention           = '100D',
+  $full                = '15D',
+  $env_var             = [],
+  $volsize             = '200',
+  $args                = '',
+  $encryption_key      = '' ) {
+
+  file { [
+    '/opt/duplicity',
+    '/opt/duplicity/conf',
+    "$cache_storage_path"
+  ]:
+    ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0750',
+  }
+
 
   file {"/opt/duplicity/${name}.sh":
     ensure  => $ensure,

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -21,16 +21,6 @@ class duplicity::common (
     recurse => true,
     matches => '*.log',
   }
-  file { [
-    '/opt/duplicity',
-    '/opt/duplicity/conf',
-    '/opt/duplicity/cache'
-  ]:
-    ensure  => directory,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0750',
-  }
 
   $module_path = get_module_path($module_name)
   file {'/opt/duplicity/duplicity-backups.sh':

--- a/templates/backup.erb
+++ b/templates/backup.erb
@@ -6,19 +6,19 @@ if [[ ! $(ps aux|grep -E "/opt/duplicity\s+.*--name=<%= @name %>.*") ]]; then
 source /opt/duplicity/conf/.env
 
 duplicity --full-if-older-than <%= @full %> --name="<%= @name %>" \
-  --verbosity 0 --progress --encrypt-key <%= @encryption_key %> <%= @args %> --archive-dir /opt/duplicity/cache --volsize <%= @volsize %> \
+  --verbosity 0 --progress --encrypt-key <%= @encryption_key %> <%= @args %> --archive-dir <%= @cache_storage_path %> --volsize <%= @volsize %> \
   --include-filelist /opt/duplicity/conf/<%= @name %>.include \
   --exclude-filelist /opt/duplicity/conf/<%= @name %>.exclude \
   <%= @source %> <%= @destination %> >> <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-$(date +%F).log 2>&1
 
 duplicity remove-older-than <%= @retention %> --name="<%= @name %>" \
   --log-file <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 0 --archive-dir <%= @cache_storage_path %> \
   --force <%= @args %> <%= @destination %>
 
 duplicity cleanup --name="<%= @name %>" --force --extra-clean \
   --log-file <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 0 --archive-dir <%= @cache_storage_path %> \
   <%= @args %> <%= @destination %>
 
 


### PR DESCRIPTION
This updates the puppet duplicity modes to allow us to specify where the cache directory will be located by introducing the variable `cache_storage_path`.
There are certain cases where we might want it stored on a separate disk due to the space needs.

I also increased the retention for backups to be 100 days just to be on the safe side.

```
>> Running puppet agent -t --environment SRE2944b
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/var/lib/puppet/lib/puppet/provider/gpg_key]/ensure: removed
Notice: /File[/var/lib/puppet/lib/puppet/provider/package/pe_gem.rb]/ensure: removed
Notice: /File[/var/lib/puppet/lib/puppet/type/gpg_key.rb]/ensure: removed
Info: Loading facts
180724 21:02:40 [Warning] Using unique option prefix key_buffer instead of key_buffer_size is deprecated and will be removed in a future release. Please use the full name instead.
Info: Caching catalog for atlassian2-i.sjc1sl.bigcommerce.net
Info: Applying configuration version 'ed5b604 - Wed Jul 25 11:57:09 2018 +1000'
Notice: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_integration]/File[/tmp/test]/ensure: created
/Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_integration]/File[/opt/duplicity/atlassian_integration.sh]/content:
--- /opt/duplicity/atlassian_integration.sh	2018-07-24 21:00:56.403723734 -0500
+++ /tmp/puppet-file20180724-6732-eahpge	2018-07-24 21:03:34.749803276 -0500
@@ -6,19 +6,19 @@
 source /opt/duplicity/conf/.env

 duplicity --full-if-older-than 15D --name="atlassian_integration" \
-  --verbosity 0 --progress --encrypt-key 986F6243  --archive-dir /opt/duplicity/cache --volsize 200 \
+  --verbosity 0 --progress --encrypt-key 986F6243  --archive-dir /tmp/test --volsize 200 \
   --include-filelist /opt/duplicity/conf/atlassian_integration.include \
   --exclude-filelist /opt/duplicity/conf/atlassian_integration.exclude \
   / swift://atlassian_integration/atlassian2-i.sjc1sl.bigcommerce.net >> /opt/duplicity/log/atlassian_integration-$(date +%F).log 2>&1

-duplicity remove-older-than 90D --name="atlassian_integration" \
+duplicity remove-older-than 100D --name="atlassian_integration" \
   --log-file /opt/duplicity/log/atlassian_integration-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 0 --archive-dir /tmp/test \
   --force  swift://atlassian_integration/atlassian2-i.sjc1sl.bigcommerce.net

 duplicity cleanup --name="atlassian_integration" --force --extra-clean \
   --log-file /opt/duplicity/log/atlassian_integration-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 0 --archive-dir /tmp/test \
    swift://atlassian_integration/atlassian2-i.sjc1sl.bigcommerce.net



Info: Computing checksum on file /opt/duplicity/atlassian_integration.sh
Info: FileBucket got a duplicate file {md5}c8aca642530092eb1d60f3475c030c71
Info: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_integration]/File[/opt/duplicity/atlassian_integration.sh]: Filebucketed /opt/duplicity/atlassian_integration.sh to puppet with sum c8aca642530092eb1d60f3475c030c71
Notice: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_integration]/File[/opt/duplicity/atlassian_integration.sh]/content: content changed '{md5}c8aca642530092eb1d60f3475c030c71' to '{md5}1a0a224d3d24daa957cc4b3058900ce1'
Notice: /Stage[main]/Cis::Section_4/Package[mysql-server]/ensure: current_value 5.5.57-0+deb8u1, should be absent (noop)
Notice: Class[Cis::Section_4]: Would have triggered 'refresh' from 1 events
Notice: Finished catalog run in 24.97 seconds
```

You can see the above is working and the cache directory /tmp/test` is setup