### PR TITLE
change to have a default log level and set it higher

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -12,6 +12,7 @@ define duplicity::backup(
   $env_var             = [],
   $volsize             = '200',
   $args                = '',
+  $log_level           = '4',
   $encryption_key      = '' ) {
 
   file { [

--- a/templates/backup.erb
+++ b/templates/backup.erb
@@ -6,19 +6,19 @@ if [[ ! $(ps aux|grep -E "/opt/duplicity\s+.*--name=<%= @name %>.*") ]]; then
 source /opt/duplicity/conf/.env
 
 duplicity --full-if-older-than <%= @full %> --name="<%= @name %>" \
-  --verbosity 0 --progress --encrypt-key <%= @encryption_key %> <%= @args %> --archive-dir <%= @cache_storage_path %> --volsize <%= @volsize %> \
+  --verbosity <%= log_level %> --progress --encrypt-key <%= @encryption_key %> <%= @args %> --archive-dir <%= @cache_storage_path %> --volsize <%= @volsize %> \
   --include-filelist /opt/duplicity/conf/<%= @name %>.include \
   --exclude-filelist /opt/duplicity/conf/<%= @name %>.exclude \
   <%= @source %> <%= @destination %> >> <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-$(date +%F).log 2>&1
 
 duplicity remove-older-than <%= @retention %> --name="<%= @name %>" \
   --log-file <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir <%= @cache_storage_path %> \
+  --verbosity <%= log_level %> --archive-dir <%= @cache_storage_path %> \
   --force <%= @args %> <%= @destination %>
 
 duplicity cleanup --name="<%= @name %>" --force --extra-clean \
   --log-file <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir <%= @cache_storage_path %> \
+  --verbosity <%= log_level %> --archive-dir <%= @cache_storage_path %> \
   <%= @args %> <%= @destination %>
 
 


### PR DESCRIPTION
I dont currently have much logged for duplicity. So set it to 4 (which is also the default if you dont specify a level). Make it possible to set the variable via hiera if you want to.

Confirmed this works as expected

```
[production][dal9sl][SRE2944g][root@atlassian1-p]:/opt/duplicity# puppetenv -b SRE2944g
>> Running puppet agent -t --environment SRE2944g
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for atlassian1-p.dal9sl.bigcommerce.net
Info: Applying configuration version '0a9639c4ce - Thu Aug 2 08:37:29 2018 +1000'
Notice: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_production]/File[/opt/duplicity/atlassian_production.sh]/content:
--- /opt/duplicity/atlassian_production.sh	2018-07-26 03:56:13.254383619 -0500
+++ /tmp/puppet-file20180801-16330-79h5tn	2018-08-01 17:51:54.513505057 -0500
@@ -6,19 +6,19 @@
 source /opt/duplicity/conf/.env

 duplicity --full-if-older-than 15D --name="atlassian_production" \
-  --verbosity 0 --progress --encrypt-key 638C522D  --archive-dir /opt/duplicity/cache --volsize 200 \
+  --verbosity 4 --progress --encrypt-key 638C522D  --archive-dir /opt/duplicity/cache --volsize 200 \
   --include-filelist /opt/duplicity/conf/atlassian_production.include \
   --exclude-filelist /opt/duplicity/conf/atlassian_production.exclude \
   / swift://atlassian_production/atlassian1-p.dal9sl.bigcommerce.net >> /opt/duplicity/log/atlassian_production-$(date +%F).log 2>&1

 duplicity remove-older-than 100D --name="atlassian_production" \
   --log-file /opt/duplicity/log/atlassian_production-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 4 --archive-dir /opt/duplicity/cache \
   --force  swift://atlassian_production/atlassian1-p.dal9sl.bigcommerce.net

 duplicity cleanup --name="atlassian_production" --force --extra-clean \
   --log-file /opt/duplicity/log/atlassian_production-cleanup-$(date +%F).log \
-  --verbosity 0 --archive-dir /opt/duplicity/cache \
+  --verbosity 4 --archive-dir /opt/duplicity/cache \
    swift://atlassian_production/atlassian1-p.dal9sl.bigcommerce.net



Info: Computing checksum on file /opt/duplicity/atlassian_production.sh
Info: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_production]/File[/opt/duplicity/atlassian_production.sh]: Filebucketed /opt/duplicity/atlassian_production.sh to puppet with sum 882ec3ff1802ba4852e24ca7a3b5c4f2
Notice: /Stage[main]/Bigcommerce_backups::Duplicity/Duplicity::Backup[atlassian_production]/File[/opt/duplicity/atlassian_production.sh]/content: content changed '{md5}882ec3ff1802ba4852e24ca7a3b5c4f2' to '{md5}873398868396a3e421e2176855d520f4'
Notice: Finished catalog run in 26.04 seconds
```